### PR TITLE
Only allow repo stars to kick off initial setup by lindsay

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only allows repo owner to initiate
-    if: github.actor == github.event.repository.owner.login
+    if: github.actor == 'lindsayplatt'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     # Issue creation steps use GitHub action, https://github.com/marketplace/actions/create-issue-from-file


### PR DESCRIPTION
Didn't work with "github owners" when I got to the repos in USGS-R since technically USGS-R is the owner. Updated so that only I have this power (though, someone can change that by making a commit that updates who the "github.actor" is)