### PR TITLE
clarify that repos need to be public

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Go to the repo that matches your username, `USGS-R/ds-gitflows-[username]`.
 
 ## I'm leading the course
 
-1. Create a new repository based on this template repo using the naming convention `ds-gitflows-[username]` for each participant. These will be considered the canonical repository for each participant.
+1. Create a new public repository based on this template repo using the naming convention `ds-gitflows-[username]` for each participant. These will be considered the canonical repository for each participant.
 1. Go to each of these new repositories you just made and (until [issue #6](https://github.com/USGS-R/ds-gitflows-template/issues/6) is fixed, ask @lindsayplatt to) star them. This will manually trigger the workflow that creates the necessary GitHub issues to complete the training using GitHub actions.
 1. Give each participant `triage` access to their repository. This will allow them to make PRs and close issues, but will prevent them from being able to write directly to the main repository. The participant will need to accept the invitation. The only other caveat is that `triage` access may make it so that they need to create a pull request before seeing the option to assign a reviewer. This was the case for someone who was not part of the `USGS-R` organization but tested the repo.
 1. Be prepared to review and merge 3 pull requests per participant (one with their first two commits, one with merge conflicts resolved, one with changes to the `.gitignore` file).


### PR DESCRIPTION
I made the repos for gitflows wrong this time! They were private, and so could not be forked due to USGS-R organizational policy. Just adding a word to the instructions here to clarify that the repos have to be public.